### PR TITLE
Add MACD strategy to strategies dropdown

### DIFF
--- a/static/js/modules/strategies.js
+++ b/static/js/modules/strategies.js
@@ -1,4 +1,4 @@
-let strategies = ['Moving Average Crossover', 'RSI Overbought/Oversold', 'MACD Divergence'];
+let strategies = ['Moving Average Crossover', 'RSI Overbought/Oversold', 'MACD Divergence', 'MACD Strategy'];
 let activeStrategy = null;
 
 export function initStrategies() {
@@ -47,6 +47,9 @@ function applyStrategyToChart(strategy) {
         case 'MACD Divergence':
             addMACDDivergence();
             break;
+        case 'MACD Strategy':
+            addMACDStrategy();
+            break;
     }
 }
 
@@ -72,6 +75,13 @@ function addRSIStrategy() {
 
 function addMACDDivergence() {
     console.log('Adding MACD Divergence strategy');
+    if (window.chartFunctions && window.chartFunctions.addChartIndicator) {
+        window.chartFunctions.addChartIndicator('macd', { fastPeriod: 12, slowPeriod: 26, signalPeriod: 9 });
+    }
+}
+
+function addMACDStrategy() {
+    console.log('Adding MACD Strategy');
     if (window.chartFunctions && window.chartFunctions.addChartIndicator) {
         window.chartFunctions.addChartIndicator('macd', { fastPeriod: 12, slowPeriod: 26, signalPeriod: 9 });
     }


### PR DESCRIPTION
Related to #6

Add MACD Strategy to strategies dropdown and implement its functionality.

* Add 'MACD Strategy' to the `strategies` array in `static/js/modules/strategies.js`.
* Implement the `addMACDStrategy` function to add the MACD strategy to the chart.
* Update the `applyStrategyToChart` function to call `addMACDStrategy` for the MACD strategy.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/TheGlitch3K/Labs/issues/6?shareId=6e06602a-9d00-46a6-96b3-9e2a665c26f9).